### PR TITLE
Update cdk-certificate npm package version reference to latest (1.0.16)

### DIFF
--- a/packages/cdk-certificate/package-lock.json
+++ b/packages/cdk-certificate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daysmart/cdk-certificate",
-  "version": "1.0.13",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cdk-certificate/package.json
+++ b/packages/cdk-certificate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daysmart/cdk-certificate",
-  "version": "1.0.13",
+  "version": "1.0.16",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
PLATFORM-1 Updated package.json and package-lock.json files to reference the latest version of the certificate package (1.0.16)