### PR TITLE
Static website construct fixes

### DIFF
--- a/packages/cdk-app-bucket/package.json
+++ b/packages/cdk-app-bucket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daysmart/cdk-app-bucket",
-  "version": "1.0.11",
+  "version": "1.0.14",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "scripts": {

--- a/packages/cdk-app-bucket/test/__snapshots__/cdk-app-bucket.test.ts.snap
+++ b/packages/cdk-app-bucket/test/__snapshots__/cdk-app-bucket.test.ts.snap
@@ -2,50 +2,36 @@
 
 exports[`AppBucket 1`] = `
 Object {
-  "Resources": Object {
-    "AppBucketBucketPolicyEB9AC237": Object {
-      "Properties": Object {
-        "Bucket": Object {
-          "Ref": "AppBucketFED55033",
-        },
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Principal": Object {
-                "CanonicalUser": Object {
-                  "Fn::GetAtt": Array [
-                    "AppBucketOriginAcessIdentityEAF14A7F",
-                    "S3CanonicalUserId",
-                  ],
-                },
-              },
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "AppBucketFED55033",
-                        "Arn",
-                      ],
-                    },
-                    "/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
+  "Outputs": Object {
+    "AppBucket": Object {
+      "Value": Object {
+        "Ref": "AppBucketFED55033",
       },
-      "Type": "AWS::S3::BucketPolicy",
     },
+    "OriginAccessIdentity": Object {
+      "Value": Object {
+        "Ref": "AppBucketOriginAcessIdentityEAF14A7F",
+      },
+    },
+  },
+  "Resources": Object {
     "AppBucketFED55033": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
-        "BucketName": "test-test2-website-bucket",
+        "BucketName": "test3-test2.test.test4",
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerPreferred",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
         "VersioningConfiguration": Object {
           "Status": "Enabled",
         },
@@ -80,23 +66,89 @@ Object {
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
-              "Action": "s3:GetObject",
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
               "Effect": "Allow",
-              "Principal": "*",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "AppBucketFED55033",
-                        "Arn",
-                      ],
-                    },
-                    "/*",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "AppBucketOriginAcessIdentityEAF14A7F",
+                    "S3CanonicalUserId",
                   ],
-                ],
+                },
               },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "AppBucketFED55033",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "AppBucketFED55033",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::1234567:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "AppBucketFED55033",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "AppBucketFED55033",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/packages/cdk-app-bucket/test/cdk-app-bucket.test.ts
+++ b/packages/cdk-app-bucket/test/cdk-app-bucket.test.ts
@@ -8,7 +8,8 @@ test("AppBucket", () => {
         stage: 'test',
         appName: 'test2',
         dynamicEnvName: 'test3',
-        projectName: 'test4'
+        projectName: 'test4',
+        sharedServicesAccountId: '1234567'
     });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();

--- a/packages/cdk-static-website/lib/StaticWebsiteCDN.ts
+++ b/packages/cdk-static-website/lib/StaticWebsiteCDN.ts
@@ -35,6 +35,11 @@ export interface StaticWebsiteCDNProps {
      * The name of the hosted zone that includes all of the domain names given
      */
     hostedZoneDomain: string;
+
+    /**
+     * A custom origin path in the S3 bucket for the CloudFront origin
+     */
+    originPath?: string;
 }
 
 /**
@@ -50,7 +55,8 @@ export class StaticWebsiteCDN extends cdk.Construct {
         const distribution = new cloudfront.Distribution(this, 'Distribution', {
             defaultBehavior: {
                 origin: new origins.S3Origin(appBucket, {
-                    originAccessIdentity: cloudfront.OriginAccessIdentity.fromOriginAccessIdentityName(this, 'OriginAccessIdentity', props.originAccessIdentity)
+                    originAccessIdentity: cloudfront.OriginAccessIdentity.fromOriginAccessIdentityName(this, 'OriginAccessIdentity', props.originAccessIdentity),
+                    originPath: props.originPath
                 }),
                 viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS
             },
@@ -58,10 +64,10 @@ export class StaticWebsiteCDN extends cdk.Construct {
             domainNames: props.domainNames,
             enableLogging: true,
             logIncludesCookies: true,
-            defaultRootObject: '/index.html',
+            defaultRootObject: 'index.html',
             errorResponses: [
                 {
-                    httpStatus: 403,
+                    httpStatus: 404,
                     responseHttpStatus: 200,
                     responsePagePath: '/index.html'
                 }

--- a/packages/cdk-static-website/package-lock.json
+++ b/packages/cdk-static-website/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daysmart/cdk-static-website",
-  "version": "0.1.2",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cdk-static-website/package.json
+++ b/packages/cdk-static-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daysmart/cdk-static-website",
-  "version": "0.1.3",
+  "version": "0.1.7",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/packages/cdk-static-website/test/__snapshots__/StaticWebsiteCDN.test.ts.snap
+++ b/packages/cdk-static-website/test/__snapshots__/StaticWebsiteCDN.test.ts.snap
@@ -46,7 +46,7 @@ Object {
           ],
           "CustomErrorResponses": Array [
             Object {
-              "ErrorCode": 403,
+              "ErrorCode": 404,
               "ResponseCode": 200,
               "ResponsePagePath": "/index.html",
             },
@@ -57,7 +57,7 @@ Object {
             "TargetOriginId": "stackWebsiteCDNDistributionOrigin1BCB5126C",
             "ViewerProtocolPolicy": "redirect-to-https",
           },
-          "DefaultRootObject": "/index.html",
+          "DefaultRootObject": "index.html",
           "Enabled": true,
           "HttpVersion": "http2",
           "IPV6Enabled": true,


### PR DESCRIPTION
- Fixes app bucket construct ACLs to make the bucket private and allow for deployments from a shared services account.
- Updates cloudfront construct to allow for a custom origin path and adds the necessary 404 redirect.